### PR TITLE
fix: slow buffer serialization in firefox

### DIFF
--- a/src/serialization/buffer.js
+++ b/src/serialization/buffer.js
@@ -1,8 +1,6 @@
 import { preArrayOf } from './utils/prepost-array-of'
 
-export const bufferFromJson = (obj) => {
-  return Buffer.from(JSON.parse(obj.data).data)
-}
+export const bufferFromJson = (obj) => Buffer.from(JSON.parse(obj.data).data)
 
 export const bufferToJson = (buf) => ({
   __ipfsPostMsgProxyType: 'Buffer',

--- a/src/serialization/buffer.js
+++ b/src/serialization/buffer.js
@@ -1,10 +1,12 @@
 import { preArrayOf } from './utils/prepost-array-of'
 
-export const bufferFromJson = (obj) => Buffer.from(obj.data)
+export const bufferFromJson = (obj) => {
+  return Buffer.from(JSON.parse(obj.data).data)
+}
 
 export const bufferToJson = (buf) => ({
   __ipfsPostMsgProxyType: 'Buffer',
-  data: Array.from(buf)
+  data: JSON.stringify(buf)
 })
 
 export const isBuffer = Buffer.isBuffer

--- a/test/functional/pubsub.test.js
+++ b/test/functional/pubsub.test.js
@@ -42,12 +42,12 @@ describe('pubsub', () => {
     await ipfsClient.pubsub.subscribe(topic, handler)
 
     // Check the subscription was registered
-    assert.equal(mockIpfs._subs.length, 1)
-    assert.equal(mockIpfs._subs[0].topic, topic)
+    assert.strictEqual(mockIpfs._subs.length, 1)
+    assert.strictEqual(mockIpfs._subs[0].topic, topic)
 
     // Close the proxy server without unsubscribing
     await closeProxyServer(ipfsServer)
 
-    assert.equal(mockIpfs._subs.length, 0)
+    assert.strictEqual(mockIpfs._subs.length, 0)
   })
 })


### PR DESCRIPTION
It turns out `Array.from(buffer)` is way slower than `JSON.stringify(buffer)`.

EDIT: Possibly not true, perhaps it's sending a large array over postMessage is way slower than sending a large string. Anyway, something like that. Either way this PR makes it fast in both Firefox _and_ Chrome which is what we want!

I'm seeing numbers like 905ms in Firefox and 455ms in Chrome for the test case from https://github.com/ipfs-shipyard/ipfs-companion/issues/485